### PR TITLE
Handle Inputs

### DIFF
--- a/spec/data/mock_schema.graphql
+++ b/spec/data/mock_schema.graphql
@@ -24,3 +24,8 @@ type MoreStuff {
   union: MyUnion
   with_params(param1: Int, param2: [Float]): Int
 }
+
+input InputType {
+  an_int: Int!
+  a_string: String
+}

--- a/spec/data/mock_schema.json
+++ b/spec/data/mock_schema.json
@@ -173,6 +173,7 @@
     "InputType": {
       "title": "InputType",
       "type": "object",
+      "input": true,
       "properties": {
         "an_int": {
           "type": "integer",

--- a/spec/data/mock_schema.json
+++ b/spec/data/mock_schema.json
@@ -169,6 +169,25 @@
         "identifier",
         "bool"
       ]
+    },
+    "InputType": {
+      "title": "InputType",
+      "type": "object",
+      "properties": {
+        "an_int": {
+          "type": "integer",
+          "required": true,
+          "title": "an_int"
+        },
+        "a_string": {
+          "type": "string",
+          "required": false,
+          "title": "a_string"
+        }
+      },
+      "required": [
+        "an_int"
+      ]
     }
   }
 }

--- a/spec/transformSpec.js
+++ b/spec/transformSpec.js
@@ -19,6 +19,6 @@ describe('GraphQL to JSON Schema transform', () => {
   });
 
   it('parses a test GraphQL Schema properly', () => {
-    expect(mockJSONSchema).toEqual(transform(mockGraphQL));
+    expect(transform(mockGraphQL)).toEqual(mockJSONSchema);
   });
 })

--- a/transform.js
+++ b/transform.js
@@ -112,12 +112,18 @@ const toSchemaObject = definition => {
     .filter(f => f.required)
     .map(f => f.title);
 
-  return {
+  let schemaObject = {
     title: definition.name.value,
     type: 'object',
     properties,
-    required
+    required,
+  };
+
+  if (definition.kind === 'InputObjectTypeDefinition') {
+    Object.assign(schemaObject, { input: true });
   }
+
+  return schemaObject;
 }
 
 /**

--- a/transform.js
+++ b/transform.js
@@ -42,6 +42,22 @@ const getPropertyType = type => {
 }
 
 /**
+ * converts the GQL arguments array into a plain JSON schema array
+ *
+ * @param      {Array}  _arguments  The GQL arguments
+ * @return     {Object}  a plain JSON array
+ */
+const toFieldArguments = _arguments => {
+  return _arguments.map(a => {
+    return {
+      title: a.name.value,
+      type: getPropertyType(a.type),
+      defaultValue: a.defaultValue
+    };
+  });
+}
+
+/**
  * maps a GQL type field onto a JSON Schema property
  *
  * @param      {object}  field   The GQL field object
@@ -52,16 +68,11 @@ const toSchemaProperty = field => {
 
   if ('$ref' in propertyType) propertyType = { allOf: [propertyType, { title: field.name.value }] };
 
-  return Object.assign(propertyType, {
-    title: field.name.value,
-    arguments: field.arguments.map(a => {
-      return {
-        title: a.name.value,
-        type: getPropertyType(a.type),
-        defaultValue: a.defaultValue
-      };
-    })
-  });
+  return Object.assign(
+    propertyType,
+    { title: field.name.value },
+    field.arguments ? { arguments: toFieldArguments(field.arguments) } : {}
+  );
 }
 
 /**


### PR DESCRIPTION
This PR fixes #1 by adding support for `input`s. 

It also means the `arguments` array won't be added unless there are arguments.

Inputs can be differentiated from normal types because they now have `input` property set to `true`.

Thanks @aboe026 for flagging this up.