### PR TITLE
fix(transform): skip directives

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -133,7 +133,10 @@ const toSchemaObject = definition => {
  * @return     {object}  A plain JavaScript object which conforms to JSON Schema
  */
 const transform = document => {
-  const definitions = document.definitions.map(toSchemaObject);
+  // ignore directives
+  const definitions = document.definitions.
+    filter(d => d.kind !== 'DirectiveDefinition').
+    map(toSchemaObject);
 
   const schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',

--- a/transform.js
+++ b/transform.js
@@ -134,9 +134,9 @@ const toSchemaObject = definition => {
  */
 const transform = document => {
   // ignore directives
-  const definitions = document.definitions.
-    filter(d => d.kind !== 'DirectiveDefinition').
-    map(toSchemaObject);
+  const definitions = document.definitions
+    .filter(d => d.kind !== 'DirectiveDefinition')
+    .map(toSchemaObject);
 
   const schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',


### PR DESCRIPTION
Hi @jakubfiala 

Just figured out that if the GraphQL schema contains some directives, the transform algorithm failed.
(because `directives` does not have any `fields`)

```
const fields = definition.fields.map(toSchemaProperty);
                                   ^

TypeError: Cannot read property 'map' of undefined
    at toSchemaObject (/xxxxx/node_modules/graphql-json-schema/transform.js:106:36)
    at Array.map (<anonymous>)
    at transform (/xxxxx/node_modules/graphql-json-schema/transform.js:136:44)
    at Object.<anonymous> (/xxxxx/generate-json-schema.js:12:24)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10)

```

This patch fix the issue by ignoring directives.