### PR TITLE
Generate JSON Schema consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ npm install graphql-json-schema
 ```js
   const transform = require('graphql-json-schema');
 
+  // transform(schemaStr, strictMode=flase)
+  //  - strict mode ensure a valid JSON schema generation
+
   const schema = transform(`
     scalar Foo
 
@@ -55,7 +58,7 @@ the code above prints the following JSON as a plain JS object:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Foo": {
       "title": "Foo",

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const parse = require('graphql/language').parse;
 const transform = require('./transform.js');
 
-module.exports = schema => {
+module.exports = (schema, strictMode = false) => {
   if (typeof schema !== 'string') throw new TypeError('GraphQL Schema must be a string');
-  return transform(parse(schema));
+  return transform(parse(schema), strictMode);
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "graphql": "^0.10.1"
   },
   "devDependencies": {
+    "ajv": "^6.4.0",
     "jasmine": "^2.6.0"
   }
 }

--- a/spec/data/mock_schema.json
+++ b/spec/data/mock_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Foo": {
       "title": "Foo",
@@ -13,12 +13,10 @@
           "$ref": "#/definitions/Foo"
         },
         {
-          "type": "string",
-          "required": false
+          "type": "string"
         },
         {
-          "type": "number",
-          "required": false
+          "type": "number"
         }
       ]
     },
@@ -37,13 +35,11 @@
       "properties": {
         "my_field": {
           "type": "integer",
-          "required": false,
           "title": "my_field",
           "arguments": []
         },
         "req_field": {
           "type": "string",
-          "required": true,
           "title": "req_field",
           "arguments": []
         },
@@ -89,10 +85,7 @@
         "first": {
           "type": "array",
           "items": {
-            "type": {
-              "type": "number",
-              "required": false
-            }
+            "type": "number"
           },
           "title": "first",
           "arguments": []
@@ -100,20 +93,15 @@
         "identifier": {
           "type": "array",
           "items": {
-            "type": {
-              "type": "string",
-              "required": false
-            }
+            "type": "string"
           },
-          "required": true,
           "title": "identifier",
           "arguments": []
         },
         "reference": {
           "allOf": [
             {
-              "$ref": "#/definitions/Stuff",
-              "required": true
+              "$ref": "#/definitions/Stuff"
             },
             {
               "title": "reference"
@@ -122,7 +110,6 @@
         },
         "bool": {
           "type": "boolean",
-          "required": true,
           "title": "bool",
           "arguments": []
         },
@@ -138,14 +125,12 @@
         },
         "with_params": {
           "type": "integer",
-          "required": false,
           "title": "with_params",
           "arguments": [
             {
               "title": "param1",
               "type": {
-                "type": "integer",
-                "required": false
+                "type": "integer"
               },
               "defaultValue": null
             },
@@ -154,10 +139,7 @@
               "type": {
                 "type": "array",
                 "items": {
-                  "type": {
-                    "type": "number",
-                    "required": false
-                  }
+                  "type": "number"
                 }
               },
               "defaultValue": null
@@ -167,6 +149,7 @@
       },
       "required": [
         "identifier",
+        "reference",
         "bool"
       ]
     },
@@ -177,12 +160,10 @@
       "properties": {
         "an_int": {
           "type": "integer",
-          "required": true,
           "title": "an_int"
         },
         "a_string": {
           "type": "string",
-          "required": false,
           "title": "a_string"
         }
       },

--- a/spec/data/mock_schema.json
+++ b/spec/data/mock_schema.json
@@ -7,7 +7,6 @@
     },
     "MyUnion": {
       "title": "MyUnion",
-      "type": "GRAPHQL_UNION",
       "oneOf": [
         {
           "$ref": "#/definitions/Foo"
@@ -22,7 +21,6 @@
     },
     "MyEnum": {
       "title": "MyEnum",
-      "type": "GRAPHQL_ENUM",
       "enum": [
         "FIRST_ITEM",
         "SECOND_ITEM",

--- a/spec/data/mock_schema_strict.json
+++ b/spec/data/mock_schema_strict.json
@@ -1,0 +1,147 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Foo": {
+            "title": "Foo"
+        },
+        "MyUnion": {
+            "title": "MyUnion",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/Foo"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "MyEnum": {
+            "title": "MyEnum",
+            "enum": [
+                "FIRST_ITEM",
+                "SECOND_ITEM",
+                "THIRD_ITEM"
+            ]
+        },
+        "Stuff": {
+            "title": "Stuff",
+            "type": "object",
+            "properties": {
+                "my_field": {
+                    "type": "integer",
+                    "title": "my_field"
+                },
+                "req_field": {
+                    "type": "string",
+                    "title": "req_field"
+                },
+                "recursion": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/MoreStuff"
+                        },
+                        {
+                            "title": "recursion"
+                        }
+                    ]
+                },
+                "custom_scalar": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Foo"
+                        },
+                        {
+                            "title": "custom_scalar"
+                        }
+                    ]
+                },
+                "enum": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/MyEnum"
+                        },
+                        {
+                            "title": "enum"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "req_field"
+            ]
+        },
+        "MoreStuff": {
+            "title": "MoreStuff",
+            "type": "object",
+            "properties": {
+                "first": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "title": "first"
+                },
+                "identifier": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "identifier"
+                },
+                "reference": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Stuff"
+                        },
+                        {
+                            "title": "reference"
+                        }
+                    ]
+                },
+                "bool": {
+                    "type": "boolean",
+                    "title": "bool"
+                },
+                "union": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/MyUnion"
+                        },
+                        {
+                            "title": "union"
+                        }
+                    ]
+                },
+                "with_params": {
+                    "type": "integer",
+                    "title": "with_params"
+                }
+            },
+            "required": [
+                "identifier",
+                "reference",
+                "bool"
+            ]
+        },
+        "InputType": {
+            "title": "InputType",
+            "type": "object",
+            "properties": {
+                "an_int": {
+                    "type": "integer",
+                    "title": "an_int"
+                },
+                "a_string": {
+                    "type": "string",
+                    "title": "a_string"
+                }
+            },
+            "required": [
+                "an_int"
+            ]
+        }
+    }
+}

--- a/spec/transformSpec.js
+++ b/spec/transformSpec.js
@@ -5,6 +5,7 @@ const Ajv = require('ajv');
 
 const ajv = new Ajv();
 const mockJSONSchema = require(path.join(__dirname, 'data/mock_schema.json'));
+const mockJSONSchemaStrict = require(path.join(__dirname, 'data/mock_schema_strict.json'));
 const mockGraphQL = fs.readFileSync(path.join(__dirname, 'data/mock_schema.graphql'), { encoding: 'utf-8' });
 
 describe('GraphQL to JSON Schema transform', () => {
@@ -40,4 +41,16 @@ describe('GraphQL to JSON Schema transform', () => {
       console.log(ajv.errors)
     }
   });
+
+  describe('with strict mode', () => {
+    it('parses a test GraphQL Schema properly', () => {
+      const schema = transform(mockGraphQL, true);
+      expect(schema).toEqual(mockJSONSchemaStrict);
+      const valid = ajv.validateSchema(schema);
+      expect(valid).toBe(true);
+      if (!valid) {
+        console.log(ajv.errors)
+      }
+    });
+  })
 })

--- a/spec/transformSpec.js
+++ b/spec/transformSpec.js
@@ -1,7 +1,9 @@
 const transform = require('../index.js');
 const fs = require('fs');
 const path = require('path');
+const Ajv = require('ajv');
 
+const ajv = new Ajv();
 const mockJSONSchema = require(path.join(__dirname, 'data/mock_schema.json'));
 const mockGraphQL = fs.readFileSync(path.join(__dirname, 'data/mock_schema.graphql'), { encoding: 'utf-8' });
 
@@ -20,5 +22,22 @@ describe('GraphQL to JSON Schema transform', () => {
 
   it('parses a test GraphQL Schema properly', () => {
     expect(transform(mockGraphQL)).toEqual(mockJSONSchema);
+  });
+
+  it('return a valid JSON Schema definition', () => {
+    const schema = transform(`
+      type Stuff {
+        my_field: Int
+        req_field: String!
+        recursion: MoreStuff
+        custom_scalar: Foo
+        enum: MyEnum
+      }
+    `);
+    const valid = ajv.validateSchema(schema);
+    expect(valid).toBe(true);
+    if (!valid) {
+      console.log(ajv.errors)
+    }
   });
 })

--- a/transform.js
+++ b/transform.js
@@ -139,7 +139,7 @@ const transform = (document, strictMode = false) => {
   // ignore directives
   const definitions = document.definitions
     .filter(d => d.kind !== 'DirectiveDefinition')
-    .map(toSchemaObject);
+    .map(toSchemaObject(strictMode));
 
   const schema = {
     $schema: 'http://json-schema.org/draft-07/schema#',

--- a/transform.js
+++ b/transform.js
@@ -133,7 +133,10 @@ const toSchemaObject = definition => {
  * @return     {object}  A plain JavaScript object which conforms to JSON Schema
  */
 const transform = document => {
-  const definitions = document.definitions.map(toSchemaObject);
+  // ignore directives
+  const definitions = document.definitions.
+    filter(d => d.kind !== 'DirectiveDefinition').
+    map(toSchemaObject);
 
   const schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',

--- a/transform.js
+++ b/transform.js
@@ -132,6 +132,7 @@ const toSchemaObject = (strictMode = false) => definition => {
  * GQL -> JSON Schema transform
  *
  * @param      {Document}  document  The GraphQL document returned by the parse function of graphql/language
+ * @param      {boolean}  strictMode  Should return a valid JSON Schema (default: false)
  * @return     {object}  A plain JavaScript object which conforms to JSON Schema
  */
 

--- a/transform.js
+++ b/transform.js
@@ -134,9 +134,9 @@ const toSchemaObject = definition => {
  */
 const transform = document => {
   // ignore directives
-  const definitions = document.definitions.
-    filter(d => d.kind !== 'DirectiveDefinition').
-    map(toSchemaObject);
+  const definitions = document.definitions
+    .filter(d => d.kind !== 'DirectiveDefinition')
+    .map(toSchemaObject);
 
   const schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',

--- a/transform.js
+++ b/transform.js
@@ -85,10 +85,12 @@ const getRequiredFields = fields => fields
  */
 const toSchemaObject = (strictMode = false) => definition => {
   if (definition.kind === 'ScalarTypeDefinition') {
-    return {
-      title: definition.name.value,
-      ...(strictMode ? {} : { type: 'GRAPHQL_SCALAR' })
-    }
+    return Object.assign(
+      {
+        title: definition.name.value
+      },
+      strictMode ? {} : { type: 'GRAPHQL_SCALAR' }
+    );
   }
   else if (definition.kind === 'UnionTypeDefinition') {
     return {


### PR DESCRIPTION
### Pull request still in development

- [x] transform return a JSON Schema version `draft-07`
- [x] specs ensures that `transform` returns a valid JSON Schema using [`ajv`](https://github.com/epoberezkin/ajv#api-validateschema) lib
- [x] drop `GRAPHQL_SCALAR`, `GRAPHQL_UNION` and `GRAPHQL_ENUM` in generated strict schema